### PR TITLE
Use toolshed for helpers

### DIFF
--- a/fw/mix.exs
+++ b/fw/mix.exs
@@ -41,6 +41,7 @@ defmodule Fw.MixProject do
       {:nerves, "~> 1.3", runtime: false},
       {:shoehorn, "~> 0.4"},
       {:ring_logger, "~> 0.4"},
+      {:toolshed, "~> 0.2"},
 
       {:dialyxir, "1.0.0-rc.4", only: :dev, runtime: false},
       {:credo, ">= 0.0.0", only: [:dev, :test], runtime: false},

--- a/fw/rootfs_overlay/etc/iex.exs
+++ b/fw/rootfs_overlay/etc/iex.exs
@@ -1,5 +1,5 @@
-# Pull in Nerves-specific helpers to the IEx session
-use Nerves.Runtime.Helpers
+# Add Toolshed helpers to the IEx session
+use Toolshed
 
 if RingLogger in Application.get_env(:logger, :backends, []) do
   IO.puts """
@@ -8,9 +8,9 @@ if RingLogger in Application.get_env(:logger, :backends, []) do
 
     RingLogger.attach
 
-  or tail the log:
+  or print the next messages in the log:
 
-    RingLogger.tail
+    RingLogger.next
   """
 end
 


### PR DESCRIPTION
We're moving to toolshed instead of Nerves.Runtime.Helpers since it's
easier to maintain and can be disabled for people who don't want any
helpers. You can also type `exit` to log out of an ssh session. :)